### PR TITLE
`hs._asm.undocumented.spaces` to `hs._asm.spaces` migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ It's configurable, hackable, and composes well with other Hammerspoon libraries.
 
 ## Setup
 
-1. install required dependency - [`hs._asm.undocumented.spaces`](https://github.com/asmagill/hs._asm.undocumented.spaces)
-2. copy `hhtwm/` folder to `~/.hammerspoon/`
-3. require the library in your `init.lua`:
+1. copy `hhtwm/` folder to `~/.hammerspoon/`
+2. require the library in your `init.lua`:
   ```lua
   hhtwm = require('hhtwm') -- it's recommended to make `hhtwm` a global object so it's not garbage collected.
   ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ It's configurable, hackable, and composes well with other Hammerspoon libraries.
 
 ## Setup
 
-1. copy `hhtwm/` folder to `~/.hammerspoon/`
-2. require the library in your `init.lua`:
+1. install required dependency - [`hs._asm.spaces`](https://github.com/asmagill/hs._asm.spaces)
+2. copy `hhtwm/` folder to `~/.hammerspoon/`
+3. require the library in your `init.lua`:
   ```lua
   hhtwm = require('hhtwm') -- it's recommended to make `hhtwm` a global object so it's not garbage collected.
   ```

--- a/hhtwm/init.lua
+++ b/hhtwm/init.lua
@@ -96,7 +96,6 @@ local getCurrentSpacesByScreen = function()
   local spacesIds = {}
 
   hs.fnutils.each(hs.screen.allScreens(), function(screen)
-    log.d("screen", screen)
     local screenSpaces = hs.spaces.spacesForScreen(screen)
 
     local visibleSpace = hs.fnutils.find(screenSpaces, function(spaceId)
@@ -721,6 +720,11 @@ end
 
 -- mostly for debugging
 module.reset = function()
+  log.d('resetting cache')
+  log.d('cache.spaces', hs.inspect(cache.spaces))
+  log.d('cache.layouts', hs.inspect(cache.layouts))
+  log.d('cache.floating', hs.inspect(cache.floating))
+
   cache.spaces   = {}
   cache.layouts  = {}
   cache.floating = {}
@@ -738,13 +742,13 @@ local loadSettings = function()
   log.d('hhtwm.floatingCache', jsonFloatingCache)
 
   -- all windows from window filter
-  local allWindows = getAllWindowsUsingSpaces()
+  -- local allWindows = getAllWindowsUsingSpaces()
 
-  local findWindowById = function(winId)
-    return hs.fnutils.find(allWindows, function(win)
-      return win:id() == winId
-    end)
-  end
+  -- local findWindowById = function(winId)
+  --   return hs.fnutils.find(allWindows, function(win)
+  --     return win == winId
+  --   end)
+  -- end
 
   -- decode tiling cache
   if jsonTilingCache then
@@ -759,7 +763,8 @@ local loadSettings = function()
         cache.layoutOptions[obj.spaceId] = obj.layoutOptions
 
         hs.fnutils.each(obj.windowIds, function(winId)
-          local win = findWindowById(winId)
+          -- local win = findWindowById(winId)
+          local win = hs.window.get(winId)
 
           log.d('restoring (spaceId, windowId, window)', obj.spaceId, winId, win)
           if win then table.insert(cache.spaces[obj.spaceId], win) end

--- a/hhtwm/init.lua
+++ b/hhtwm/init.lua
@@ -32,7 +32,7 @@ local ensureCacheSpaces = function(spaceId)
 end
 
 local getCurrentSpacesIds = function()
-  return spaces.activeSpaces()
+  return hs.spaces.activeSpaces()
 end
 
 local getSpaceId = function(win)
@@ -91,12 +91,13 @@ local getScreenBySpaceId = function(spaceId)
 end
 
 local getCurrentSpacesByScreen = function()
-  local currentSpaces = spaces.query(spaces.masks.currentSpaces)
+  local currentSpaces = hs.spaces.activeSpaces()
 
   local spacesIds = {}
 
   hs.fnutils.each(hs.screen.allScreens(), function(screen)
-    local screenSpaces = screen:spaces()
+    log.d("screen", screen)
+    local screenSpaces = hs.spaces.spacesForScreen(screen)
 
     local visibleSpace = hs.fnutils.find(screenSpaces, function(spaceId)
       return hs.fnutils.contains(currentSpaces, spaceId)


### PR DESCRIPTION
Remove the dependency on the deprecated [hs._asm.undocumented.spaces](https://github.com/asmagill/hs._asm.undocumented.spaces), and instead use the built-in `hs.spaces` module.

## Validation

The following functions were tested to be working following the happy-path.

### Module Related

- [x] `hhtwm.start()`
- [x] `hhtwm.stop()`
- [x] `hhtwm.tile()`
- [x] `hhtwm.reset()`

### Window Related

- [x] `hhtwm.swapInDirection(win, dir)`
- [x] `hhtwm.throwToScreen(win, dir)`
- [x] `hhtwm.throwToScreenUsingSpaces(win, dir)`
- [x] `hhtwm.throwToSpace(win, spaceIndex)`
- [x] `hhtwm.isFloating(win)`
- [x] `hhtwm.toggleFloat(win)`

### Layout Related

- [x] `hhtwm.setLayout(layout)`
- [x] `hhtwm.getLayouts()`
- [x] `hhtwm.getLayout()`
- [x] `hhtwm.resizeLayout(resizeOption)`
- [x] `hhtwm.equalizeLayout()`